### PR TITLE
Use url_for to allow running CTFd on a subpath

### DIFF
--- a/src/assets/index.html
+++ b/src/assets/index.html
@@ -33,10 +33,10 @@
                 <td>{{ challenge.id }}</td>
                 <td>{{ challenge.name }}</td>
                 <td>{{ challenge.state }}</td>
-                <td>{{ challenge.timed_release }}  {% if challenge.timed_release != "—" %}&nbsp;&nbsp;<a href="/admin/timed_releases/delete/{{ challenge.id }}">❌</a>{% endif %}  </td>
+                <td>{{ challenge.timed_release }}  {% if challenge.timed_release != "—" %}&nbsp;&nbsp;<a href="{{ url_for('timed_releases.delete_timed_release', chal_id=challenge.id) }}">❌</a>{% endif %}  </td>
                 <td>
                 {% if challenge.state == "hidden" %}
-                    <form class="update-timed-release" action="/admin/timed_releases/{{ challenge.id }}" method="POST">
+                    <form class="update-timed-release" action="{{ url_for('timed_releases.update_timed_release', chal_id=challenge.id) }}" method="POST">
                         <input value="{{ Session.nonce }}" name="nonce" hidden>
 
                         <input type="datetime-local" name="release"
@@ -55,5 +55,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/plugins/ctfd-timed-releases-v2/src/assets/script.js"></script>
+<script src="{{ url_for('plugins.ctfd-timed-releases-v2.src.assets', path='script.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
Thanks for your work on this plugin.

Due to the hardcoded paths in index.html, the plugin doesn't work when run on a subpath (e.g. example.com/ctfd).
This is probably only done when testing, and probably is never a problem on a production deployment, but if you're interested in the fix then merge it.

I haven't managed to explicitly test this without a subpath, but I think this is the "flask" way of doing things and follows how the rest of the ctfd templates work so I highly doubt there would be an issue.